### PR TITLE
build: install `zod`, `zod-openapi`, and `swagger-ui-express`

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,11 +12,15 @@
         "@prisma/client": "^6.3.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "swagger-ui-express": "^5.0.1",
+        "zod": "^3.24.2",
+        "zod-openapi": "^4.2.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
+        "@types/swagger-ui-express": "^4.1.7",
         "prisma": "^6.3.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.7.3"
@@ -134,6 +138,13 @@
       "dependencies": {
         "@prisma/debug": "6.3.1"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -294,6 +305,17 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.7.tgz",
+      "integrity": "sha512-ovLM9dNincXkzH4YwyYpll75vhzPBlWx6La89wwvYH7mHjVpf0X0K/vR/aUM7SRxmr5tt9z7E5XJcjQ46q+S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -1621,6 +1643,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.3.tgz",
+      "integrity": "sha512-G33HFW0iFNStfY2x6QXO2JYVMrFruc8AZRX0U/L71aA7WeWfX2E5Nm8E/tsipSZJeIZZbSjUDeynLK/wcuNWIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1838,6 +1884,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-openapi": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/zod-openapi/-/zod-openapi-4.2.3.tgz",
+      "integrity": "sha512-i0SqpcdXfsvVWTIY1Jl3Tk421s9fBIkpXvaA86zDas+8FjfZjm+GX6ot6SPB2SyuHwUNTN02gE5uIVlYXlyrDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.21.4"
       }
     }
   }

--- a/api/package.json
+++ b/api/package.json
@@ -15,11 +15,15 @@
     "@prisma/client": "^6.3.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "swagger-ui-express": "^5.0.1",
+    "zod": "^3.24.2",
+    "zod-openapi": "^4.2.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
+    "@types/swagger-ui-express": "^4.1.7",
     "prisma": "^6.3.1",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.7.3"


### PR DESCRIPTION
This pull request includes several additions to the `api/package.json` and `api/package-lock.json` files to introduce new dependencies and their type definitions. The most important changes are the addition of Swagger and Zod libraries for API documentation and validation.

New dependencies added:

* Added `swagger-ui-express` to facilitate serving Swagger API documentation (`api/package.json`, `api/package-lock.json`). [[1]](diffhunk://#diff-5ceabdff55ebcf9aa8551146715d518c3d1454c7df52593dc510fedad73aca91L15-R23) [[2]](diffhunk://#diff-d0ab9c1cc78fba971b5270314ad877706d340d099b42f46a406fc5de6a32fdf0L18-R26)
* Added `zod` and `zod-openapi` for schema validation and OpenAPI integration (`api/package.json`, `api/package-lock.json`). [[1]](diffhunk://#diff-5ceabdff55ebcf9aa8551146715d518c3d1454c7df52593dc510fedad73aca91L15-R23) [[2]](diffhunk://#diff-d0ab9c1cc78fba971b5270314ad877706d340d099b42f46a406fc5de6a32fdf0L18-R26)

New type definitions added:

* Added `@types/swagger-ui-express` for TypeScript support of `swagger-ui-express` (`api/package.json`, `api/package-lock.json`). [[1]](diffhunk://#diff-5ceabdff55ebcf9aa8551146715d518c3d1454c7df52593dc510fedad73aca91R309-R319) [[2]](diffhunk://#diff-d0ab9c1cc78fba971b5270314ad877706d340d099b42f46a406fc5de6a32fdf0L18-R26)