### PR TITLE
feat(prisma): create entity mappers

### DIFF
--- a/api/src/infra/database/mappers/prisma-address-mapper.ts
+++ b/api/src/infra/database/mappers/prisma-address-mapper.ts
@@ -1,0 +1,50 @@
+import { Address } from "@core/entities/address";
+import { CUID } from "@core/entities/types/CUID";
+import { PrismaAssociateMapper } from "@infra/database/mappers/prisma-associate-mapper";
+import { Prisma } from "@prisma/client";
+
+type PrismaAddress = Prisma.AddressGetPayload<{}> & {
+  associates?: Prisma.AssociateGetPayload<{}>[];
+};
+
+export class PrismaAddressMapper {
+  static toEntity(raw: PrismaAddress): Address {
+    return Address.create({
+      id: new CUID(raw.id),
+      street: raw.street,
+      number: raw.number,
+      complement: raw.complement,
+      neighborhood: raw.neighborhood,
+      city: raw.city,
+      state: raw.state,
+      country: raw.country,
+      zipCode: raw.zipCode,
+      ...(raw.associates && {
+        associates: new Map(
+          raw.associates.map((associate) => [
+            associate.id,
+            PrismaAssociateMapper.toEntity(associate),
+          ])
+        ),
+      }),
+      createdAt: raw.createdAt,
+      updatedAt: raw.updatedAt,
+    });
+  }
+
+  static toPersistence(address: Address): Prisma.AddressUncheckedCreateInput {
+    return {
+      id: address.id.value,
+      street: address.street,
+      number: address.number,
+      complement: address.complement,
+      neighborhood: address.neighborhood,
+      city: address.city,
+      state: address.state,
+      country: address.country,
+      zipCode: address.zipCode,
+      createdAt: address.createdAt,
+      updatedAt: address.updatedAt,
+    };
+  }
+}

--- a/api/src/infra/database/mappers/prisma-associate-mapper.ts
+++ b/api/src/infra/database/mappers/prisma-associate-mapper.ts
@@ -1,0 +1,49 @@
+import { Associate } from "@core/entities/associate";
+import { CUID } from "@core/entities/types/CUID";
+import { PrismaAddressMapper } from "@infra/database/mappers/prisma-address-mapper";
+import { PrismaPaymentMapper } from "@infra/database/mappers/prisma-payment-mapper";
+import { Prisma } from "@prisma/client";
+
+type PrismaAssociate = Prisma.AssociateGetPayload<{}> & {
+  address?: Prisma.AddressGetPayload<{}>;
+  payments?: Prisma.PaymentGetPayload<{}>[];
+};
+
+export class PrismaAssociateMapper {
+  static toEntity(raw: PrismaAssociate): Associate {
+    return Associate.create({
+      id: new CUID(raw.id),
+      fullName: raw.fullName,
+      email: raw.email,
+      phone: raw.phone,
+      addressId: new CUID(raw.addressId),
+      ...(raw.address && {
+        address: PrismaAddressMapper.toEntity(raw.address),
+      }),
+      ...(raw.payments && {
+        payments: new Map(
+          raw.payments.map((payment) => [
+            payment.id,
+            PrismaPaymentMapper.toEntity(payment),
+          ])
+        ),
+      }),
+      createdAt: raw.createdAt,
+      updatedAt: raw.updatedAt,
+    });
+  }
+
+  static toPersistence(
+    associate: Associate
+  ): Prisma.AssociateUncheckedCreateInput {
+    return {
+      id: associate.id.value,
+      fullName: associate.fullName,
+      email: associate.email,
+      phone: associate.phone,
+      addressId: associate.addressId.value,
+      createdAt: associate.createdAt,
+      updatedAt: associate.updatedAt,
+    };
+  }
+}

--- a/api/src/infra/database/mappers/prisma-mensality-mapper.ts
+++ b/api/src/infra/database/mappers/prisma-mensality-mapper.ts
@@ -1,0 +1,42 @@
+import { Mensality } from "@core/entities/mensality";
+import { CUID } from "@core/entities/types/CUID";
+import { PrismaPaymentMapper } from "@infra/database/mappers/prisma-payment-mapper";
+import { Prisma } from "@prisma/client";
+
+type PrismaMensality = Prisma.MensalityGetPayload<{}> & {
+  payments?: Prisma.PaymentGetPayload<{}>[];
+};
+
+export class PrismaMensalityMapper {
+  static toEntity(raw: PrismaMensality): Mensality {
+    return Mensality.create({
+      id: new CUID(raw.id),
+      month: raw.month,
+      year: raw.year,
+      priceInCents: raw.priceInCents,
+      ...(raw.payments && {
+        payments: new Map(
+          raw.payments.map((payment) => [
+            payment.id,
+            PrismaPaymentMapper.toEntity(payment),
+          ])
+        ),
+      }),
+      createdAt: raw.createdAt,
+      updatedAt: raw.updatedAt,
+    });
+  }
+
+  static toPersistence(
+    mensality: Mensality
+  ): Prisma.MensalityUncheckedCreateInput {
+    return {
+      id: mensality.id.value,
+      month: mensality.month,
+      year: mensality.year,
+      priceInCents: mensality.priceInCents,
+      createdAt: mensality.createdAt,
+      updatedAt: mensality.updatedAt,
+    };
+  }
+}

--- a/api/src/infra/database/mappers/prisma-payment-mapper.ts
+++ b/api/src/infra/database/mappers/prisma-payment-mapper.ts
@@ -1,0 +1,32 @@
+import { Payment } from "@core/entities/payment";
+import { CUID } from "@core/entities/types/CUID";
+import { Prisma } from "@prisma/client";
+
+type PrismaPayment = Prisma.PaymentGetPayload<{}> & {
+  associate?: Prisma.AssociateGetPayload<{}>;
+};
+
+export class PrismaPaymentMapper {
+  static toEntity(raw: PrismaPayment): Payment {
+    return Payment.create({
+      id: new CUID(raw.id),
+      associateId: new CUID(raw.associateId),
+      ...(raw.associate && {
+        associate: PrismaAssociateMapper.toEntity(raw.associate),
+      }),
+      date: raw.date,
+      createdAt: raw.createdAt,
+      updatedAt: raw.updatedAt,
+    });
+  }
+
+  static toPersistence(payment: Payment): Prisma.PaymentUncheckedCreateInput {
+    return {
+      id: payment.id.value,
+      associateId: payment.associateId.value,
+      date: payment.date,
+      createdAt: payment.createdAt,
+      updatedAt: payment.updatedAt,
+    };
+  }
+}

--- a/api/src/infra/database/mappers/prisma-session-mapper.ts
+++ b/api/src/infra/database/mappers/prisma-session-mapper.ts
@@ -1,0 +1,35 @@
+import { Session } from "@core/entities/session";
+import { CUID } from "@core/entities/types/CUID";
+import { PrismaUserMapper } from "@infra/database/mappers/prisma-user-mapper";
+import { Prisma } from "@prisma/client";
+
+type PrismaSession = Prisma.SessionGetPayload<{}> & {
+  user?: Prisma.UserGetPayload<{}>;
+};
+
+export class PrismaSessionMapper {
+  static toEntity(raw: PrismaSession): Session {
+    return Session.create({
+      id: new CUID(raw.id),
+      ipAddress: raw.ipAddress,
+      userAgent: raw.userAgent,
+      userId: new CUID(raw.userId),
+      ...(raw.user && {
+        user: PrismaUserMapper.toEntity(raw.user),
+      }),
+      createdAt: raw.createdAt,
+      updatedAt: raw.updatedAt,
+    });
+  }
+
+  static toPersistence(session: Session): Prisma.SessionUncheckedCreateInput {
+    return {
+      id: session.id.value,
+      ipAddress: session.ipAddress,
+      userAgent: session.userAgent,
+      userId: session.userId.value,
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
+    };
+  }
+}

--- a/api/src/infra/database/mappers/prisma-system-config-mapper.ts
+++ b/api/src/infra/database/mappers/prisma-system-config-mapper.ts
@@ -1,0 +1,31 @@
+import { SystemConfig } from "@core/entities/system-config";
+import { CUID } from "@core/entities/types/CUID";
+import { Prisma } from "@prisma/client";
+
+type PrismaSystemConfig = Prisma.SystemConfigGetPayload<{}>;
+
+export class PrismaSystemConfigMapper {
+  static toEntity(raw: PrismaSystemConfig): SystemConfig {
+    return SystemConfig.create({
+      id: new CUID(raw.id),
+      key: raw.key,
+      value: raw.value,
+      valueType: raw.valueType,
+      createdAt: raw.createdAt,
+      updatedAt: raw.updatedAt,
+    });
+  }
+
+  static toPersistence(
+    systemConfig: SystemConfig
+  ): Prisma.SystemConfigUncheckedCreateInput {
+    return {
+      id: systemConfig.id.value,
+      key: systemConfig.key,
+      value: systemConfig.value,
+      valueType: systemConfig.value,
+      createdAt: systemConfig.createdAt,
+      updatedAt: systemConfig.updatedAt,
+    };
+  }
+}

--- a/api/src/infra/database/mappers/prisma-user-mapper.ts
+++ b/api/src/infra/database/mappers/prisma-user-mapper.ts
@@ -1,0 +1,37 @@
+import { CUID } from "@core/entities/types/CUID";
+import { User } from "@core/entities/user";
+import { Prisma } from "@prisma/client";
+
+type PrismaUser = Prisma.UserGetPayload<{}>;
+
+export class PrismaUserMapper {
+  static toEntity(raw: PrismaUser): User {
+    return User.create({
+      id: new CUID(raw.id),
+      email: raw.email,
+      password: raw.password,
+      firstName: raw.firstName,
+      lastName: raw.lastName,
+      roles: raw.roles,
+      active: raw.active,
+      verifiedAt: raw.verifiedAt,
+      createdAt: raw.createdAt,
+      updatedAt: raw.updatedAt,
+    });
+  }
+
+  static toPersistence(user: User): Prisma.UserUncheckedCreateInput {
+    return {
+      id: user.id.value,
+      email: user.email,
+      password: user.password,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      roles: user.roles,
+      active: user.active,
+      verifiedAt: user.verifiedAt,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    };
+  }
+}


### PR DESCRIPTION
This pull request introduces several new mappers to convert between Prisma database models and core entity models. These mappers facilitate the transformation of data between the database layer and the application layer, ensuring consistency and ease of use.

The most important changes include:

### Mapper Implementations:

* [`api/src/infra/database/mappers/prisma-address-mapper.ts`](diffhunk://#diff-fd2b3f8246c26821874b3c8a0ecd14a8ff52912fb9f82575641511cecdad8ddbR1-R50): Added `PrismaAddressMapper` to convert between `Prisma.Address` and `Address` entities.

* [`api/src/infra/database/mappers/prisma-associate-mapper.ts`](diffhunk://#diff-7545b25b288b7348800c1e5a4e4f40b3bb3a44e98026344e4503c59526fc46fdR1-R49): Introduced `PrismaAssociateMapper` for mapping `Prisma.Associate` to `Associate` entities.

* [`api/src/infra/database/mappers/prisma-mensality-mapper.ts`](diffhunk://#diff-e6f196aec6946190c053164902a83bb387ac58f607fe0c48fcba8ef5eead6c84R1-R42): Created `PrismaMensalityMapper` to handle conversions between `Prisma.Mensality` and `Mensality` entities.

* [`api/src/infra/database/mappers/prisma-payment-mapper.ts`](diffhunk://#diff-1a5ddf5ed27b571cdd755127b4c26c3a5235014f31338c16de511a64d96da097R1-R32): Implemented `PrismaPaymentMapper` to map `Prisma.Payment` to `Payment` entities.

* [`api/src/infra/database/mappers/prisma-session-mapper.ts`](diffhunk://#diff-7633dc96e5f04de6a434bd785f287eac86d3f58cb6644dd01c7e5c85ae18617eR1-R35): Added `PrismaSessionMapper` for converting `Prisma.Session` to `Session` entities.

* [`api/src/infra/database/mappers/prisma-system-config-mapper.ts`](diffhunk://#diff-397b6d4e9c10f993c4525638aeabdded84b0c67990e149a22ac82bd59bc6a4f2R1-R31): Introduced `PrismaSystemConfigMapper` to handle transformations between `Prisma.SystemConfig` and `SystemConfig` entities.

* [`api/src/infra/database/mappers/prisma-user-mapper.ts`](diffhunk://#diff-cfe4d6f6c1e0884c626d426e478911851af37efbe7b354ff226a3346cee2e125R1-R37): Created `PrismaUserMapper` for mapping `Prisma.User` to `User` entities.