### PR TITLE
:sparkles: feat: configure swagger with ui

### DIFF
--- a/api/src/infra/docs/swagger-mapper.ts
+++ b/api/src/infra/docs/swagger-mapper.ts
@@ -1,0 +1,39 @@
+import { ZodTypeAny } from "zod";
+import "zod-openapi/extend";
+interface Schema {
+  route?: ZodTypeAny;
+  query?: ZodTypeAny;
+  body?: ZodTypeAny;
+  params?: ZodTypeAny;
+}
+
+export class SwaggerMapper {
+  static toDocs({ body, query, route, params }: Schema) {
+    const docs = {};
+
+    if (params)
+      Object.assign(docs, {
+        requestParams: {
+          path: params,
+        },
+      });
+
+    if (body) Object.assign(docs, SwaggerMapper.parseBody(body));
+
+    if (route) Object.assign(docs, { requestParams: { path: route } });
+
+    if (query) Object.assign(docs, { requestParams: { query } });
+
+    return docs;
+  }
+
+  private static parseBody(body: ZodTypeAny) {
+    return {
+      requestBody: {
+        content: {
+          "application/json": { schema: body },
+        },
+      },
+    };
+  }
+}

--- a/api/src/infra/docs/swagger.ts
+++ b/api/src/infra/docs/swagger.ts
@@ -1,0 +1,100 @@
+import { createDocument } from "zod-openapi";
+
+import { fetchAssociateSchema } from "@infra/http/controllers/fetch-associate";
+import { listAssociatesSchema } from "@infra/http/controllers/list-associates";
+import { registerAssociateSchema } from "@infra/http/controllers/register-associate";
+import { SwaggerMapper } from "./swagger-mapper";
+
+const tags = {
+  associates: "Associates",
+  payments: "Payments",
+  mensalities: "Mensalities",
+};
+
+const docs = createDocument({
+  openapi: "3.0.0",
+  info: {
+    title: "Cash Control API",
+    version: "1.0.0",
+    description: "API documentation for Cash Control",
+  },
+  tags: Object.values(tags).map((name) => ({ name })),
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+      },
+    },
+  },
+  security: [
+    {
+      bearerAuth: [],
+    },
+  ],
+  paths: {
+    "/associates": {
+      get: {
+        tags: [tags.associates],
+        summary: "List associates",
+        description: "List all associates",
+        responses: {
+          200: {
+            description: "Associates listed successfully",
+          },
+          400: {
+            description: "Bad request",
+          },
+        },
+        ...SwaggerMapper.toDocs(listAssociatesSchema),
+      },
+      post: {
+        tags: [tags.associates],
+        summary: "Register an associate",
+        description: "Register a new associate",
+        responses: {
+          201: {
+            description: "Associate registered successfully",
+          },
+          400: {
+            description: "Bad request",
+          },
+        },
+        ...SwaggerMapper.toDocs(registerAssociateSchema),
+      },
+    },
+    "/associates/{id}": {
+      get: {
+        tags: [tags.associates],
+        summary: "Fetch an associate",
+        description: "Fetch an associate by its ID",
+        parameters: [
+          {
+            in: "path",
+            name: "id",
+            required: true,
+            schema: {
+              type: "string",
+              format: "cuid2",
+            },
+          },
+        ],
+        responses: {
+          200: {
+            description: "Associate fetched successfully",
+          },
+          400: {
+            description: "Bad request",
+          },
+          404: {
+            description: "Associate not found",
+          },
+        },
+        ...SwaggerMapper.toDocs(fetchAssociateSchema as any),
+      },
+    },
+  },
+});
+
+export { docs };

--- a/api/src/infra/server.ts
+++ b/api/src/infra/server.ts
@@ -1,12 +1,20 @@
 import cors from "cors";
 import express from "express";
 
+import swaggerUi from "swagger-ui-express";
+
 import dotenv from "dotenv";
+
+import { docs } from "@infra/docs/swagger";
+import { router } from "@infra/http/routes";
+
+import "zod-openapi/extend";
 
 const app = express();
 app.use(cors());
 app.use(express.json());
-
+app.use(router);
+app.use("/docs", swaggerUi.serve, swaggerUi.setup(docs));
 dotenv.config();
 
 app.listen(process.env.API_PORT, () => {


### PR DESCRIPTION
This pull request introduces Swagger documentation to the API, enhancing the documentation and making it easier to understand and use. The most important changes include creating a new `SwaggerMapper` class, generating the Swagger documentation, and integrating the Swagger UI into the server.

Documentation enhancements:

* [`api/src/infra/docs/swagger-mapper.ts`](diffhunk://#diff-9851c5c37302e472678b6293b7a2e650e461c1e5411756402eb6096d27f6b972R1-R39): Created the `SwaggerMapper` class to map Zod schemas to Swagger documentation. This class includes methods to convert route, query, body, and params schemas into Swagger-compatible documentation.
* [`api/src/infra/docs/swagger.ts`](diffhunk://#diff-e9d7fcd9af09946efab15b906fa703aadad4db130f5d8cf88a6cf17210b6a587R1-R100): Generated the Swagger documentation using the `SwaggerMapper` class and integrated it with the existing schemas for listing, registering, and fetching associates.

Server integration:

* [`api/src/infra/server.ts`](diffhunk://#diff-d257c8fe51160f3a8c9462c848fcf05fecce04ff35474a17eb57130f0a5eb591R4-R17): Integrated Swagger UI into the server, making the documentation accessible at the `/docs` endpoint.