### PR TITLE
:sparkles: feat(http-presenters): create initial setup for http presenters

### DIFF
--- a/api/src/infra/http/presenters/associate-presenter.ts
+++ b/api/src/infra/http/presenters/associate-presenter.ts
@@ -1,0 +1,17 @@
+import { Associate, AssociateProps } from "@core/entities/associate";
+
+import { View } from "@infra/types/view";
+
+export class AssociatePresenter {
+  static toDTO(associate?: Associate): View<AssociateProps> {
+    if (associate)
+      return {
+        id: associate.id,
+        fullName: associate.fullName,
+        email: associate.email,
+        phone: associate.phone,
+        createdAt: associate.createdAt,
+        updatedAt: associate.updatedAt,
+      };
+  }
+}


### PR DESCRIPTION
This pull request introduces a new presenter class to the `api/src/infra/http/presenters` directory. The primary purpose of this change is to convert `Associate` entities into a Data Transfer Object (DTO) format.

Most important change:

* [`api/src/infra/http/presenters/associate-presenter.ts`](diffhunk://#diff-1655c57c0898b04bd91d5f2bd97c0a08c9e3124d4faf229b238e139ebe7d643eR1-R17): Added a new `AssociatePresenter` class with a static method `toDTO` to convert `Associate` entities to a DTO format. This method includes mapping properties such as `id`, `fullName`, `email`, `phone`, `createdAt`, and `updatedAt` from the `Associate` entity.