### PR TITLE
feat: create partial interface type

### DIFF
--- a/api/src/infra/types/view.ts
+++ b/api/src/infra/types/view.ts
@@ -1,0 +1,3 @@
+import { DeepPartial } from "utility-types";
+
+export type View<T extends object> = DeepPartial<T> | void;


### PR DESCRIPTION
This pull request includes a small change to the `api/src/infra/types/view.ts` file. The change introduces a new type alias `View` that can be a `DeepPartial` of a given object type or `void`.

* [`api/src/infra/types/view.ts`](diffhunk://#diff-744b2c4927df547dde7c57d55b976800a63a1e758a0c2ef6750ec32abdfd4fcdR1-R3): Added a new type alias `View` that uses `DeepPartial` from the `utility-types` package.