### PR TITLE
:sparkles: feat(http-routes): create initial http routes file with some associate endpoints

### DIFF
--- a/api/src/infra/http/routes/index.ts
+++ b/api/src/infra/http/routes/index.ts
@@ -1,0 +1,10 @@
+import { fetchAssociateController } from "@infra/http/controllers/fetch-associate";
+import { listAssociatesController } from "@infra/http/controllers/list-associates";
+import { registerAssociateController } from "@infra/http/controllers/register-associate";
+import { Router } from "express";
+
+export const router = Router();
+
+router.get("/associates", listAssociatesController);
+router.post("/associates", registerAssociateController);
+router.get("/associates/:id", fetchAssociateController);


### PR DESCRIPTION
This pull request introduces new routes for handling associates in the `api/src/infra/http/routes/index.ts` file. The changes include importing necessary controllers and defining routes for listing, registering, and fetching associates.

New routes for handling associates:

* [`api/src/infra/http/routes/index.ts`](diffhunk://#diff-1344b77389dd0665c1674308dcc816cf70fe40d5bd749ffbcaf874f129bfbdf9R1-R10): Added imports for `fetchAssociateController`, `listAssociatesController`, and `registerAssociateController`. Defined routes for listing associates (`GET /associates`), registering an associate (`POST /associates`), and fetching an associate by ID (`GET /associates/:id`).