### PR TITLE
Feat/register mensality http

### DIFF
--- a/api/src/infra/docs/swagger.ts
+++ b/api/src/infra/docs/swagger.ts
@@ -3,7 +3,9 @@ import { createDocument } from "zod-openapi";
 import { fetchAssociateSchema } from "@infra/http/controllers/fetch-associate";
 import { listAssociatesSchema } from "@infra/http/controllers/list-associates";
 import { registerAssociateSchema } from "@infra/http/controllers/register-associate";
-import { SwaggerMapper } from "./swagger-mapper";
+import { registerMensalitySchema } from "@infra/http/controllers/register-mensality";
+
+import { SwaggerMapper } from "@infra/docs/swagger-mapper";
 
 const tags = {
   associates: "Associates",
@@ -92,6 +94,22 @@ const docs = createDocument({
           },
         },
         ...SwaggerMapper.toDocs(fetchAssociateSchema as any),
+      },
+    },
+    "/mensalities": {
+      post: {
+        tags: [tags.mensalities],
+        summary: "Register a mensality",
+        description: "Register a new mensality",
+        responses: {
+          201: {
+            description: "Mensality registered successfully",
+          },
+          400: {
+            description: "Bad request",
+          },
+        },
+        ...SwaggerMapper.toDocs(registerMensalitySchema),
       },
     },
   },

--- a/api/src/infra/http/controllers/register-mensality.ts
+++ b/api/src/infra/http/controllers/register-mensality.ts
@@ -1,0 +1,58 @@
+import container from "@infra/container";
+import { NextFunction, Request, Response } from "express";
+import { z } from "zod";
+import "zod-openapi/extend";
+
+import { RegisterMensalityUseCase } from "@core/use-cases/register-mensality";
+
+export const registerMensalitySchema = {
+  body: z.object({
+    month: z
+      .enum([
+        "JAN",
+        "FEB",
+        "MAR",
+        "APR",
+        "MAY",
+        "JUN",
+        "JUL",
+        "AUG",
+        "SEP",
+        "OCT",
+        "NOV",
+        "DEC",
+      ])
+      .openapi({ description: "Mensality month" }),
+    year: z
+      .number()
+      .int()
+      .positive()
+      .openapi({ description: "Mensality year" }),
+    value: z
+      .number()
+      .int()
+      .positive()
+      .openapi({ description: "Mensality value in cents" }),
+  }),
+};
+
+export async function registerMensalityController(
+  request: Request,
+  response: Response,
+  next: NextFunction
+): Promise<Response | void> {
+  try {
+    const { month, year, value } = registerMensalitySchema.body.parse(
+      request.body
+    );
+
+    const registerMensalityUseCase =
+      container.resolve<RegisterMensalityUseCase>("registerMensalityUseCase");
+
+    await registerMensalityUseCase.execute({ month, year, value });
+
+    return response.status(201).send();
+  } catch (error) {
+    next(error);
+  }
+}

--- a/api/src/infra/http/presenters/mensality-presenter.ts
+++ b/api/src/infra/http/presenters/mensality-presenter.ts
@@ -1,0 +1,17 @@
+import { Mensality, MensalityProps } from "@core/entities/mensality";
+
+import { View } from "@infra/types/view";
+
+export class MensalityPresenter {
+  static toDTO(mensality?: Mensality): View<MensalityProps> {
+    if (mensality)
+      return {
+        id: mensality.id,
+        month: mensality.month,
+        year: mensality.year,
+        priceInCents: mensality.priceInCents,
+        createdAt: mensality.createdAt,
+        updatedAt: mensality.updatedAt,
+      };
+  }
+}

--- a/api/src/infra/http/routes/index.ts
+++ b/api/src/infra/http/routes/index.ts
@@ -1,6 +1,7 @@
 import { fetchAssociateController } from "@infra/http/controllers/fetch-associate";
 import { listAssociatesController } from "@infra/http/controllers/list-associates";
 import { registerAssociateController } from "@infra/http/controllers/register-associate";
+import { registerMensalityController } from "@infra/http/controllers/register-mensality";
 import { Router } from "express";
 
 export const router = Router();
@@ -8,3 +9,5 @@ export const router = Router();
 router.get("/associates", listAssociatesController);
 router.post("/associates", registerAssociateController);
 router.get("/associates/:id", fetchAssociateController);
+
+router.post("/mensalities", registerMensalityController);


### PR DESCRIPTION
This pull request introduces a new feature to handle the registration of mensalities. The most important changes include the addition of a new controller, schema, and route for mensalities, as well as updates to the Swagger documentation.

### New Feature: Registration of Mensalities

* [`api/src/infra/http/controllers/register-mensality.ts`](diffhunk://#diff-7fdf8caf890b28c7db400b760856b5ff331de8101ef323a7323240b6ca859809R1-R58): Added a new controller `registerMensalityController` and schema `registerMensalitySchema` for handling mensality registration.

* [`api/src/infra/http/routes/index.ts`](diffhunk://#diff-1344b77389dd0665c1674308dcc816cf70fe40d5bd749ffbcaf874f129bfbdf9R4-R13): Added a new route `/mensalities` to handle POST requests using the `registerMensalityController`.

### Documentation Updates

* [`api/src/infra/docs/swagger.ts`](diffhunk://#diff-e9d7fcd9af09946efab15b906fa703aadad4db130f5d8cf88a6cf17210b6a587R99-R114): Updated Swagger documentation to include the new `/mensalities` endpoint and its associated schema.

### Import Adjustments

* [`api/src/infra/docs/swagger.ts`](diffhunk://#diff-e9d7fcd9af09946efab15b906fa703aadad4db130f5d8cf88a6cf17210b6a587L6-R8): Adjusted imports to include the new `registerMensalitySchema` and moved `SwaggerMapper` import to a different path.

### Presenter Addition

* [`api/src/infra/http/presenters/mensality-presenter.ts`](diffhunk://#diff-bced6fe86809a28b01772ff50031ce1bc314b7444a8ce3ca87539c32b0b56a23R1-R17): Created `MensalityPresenter` to convert `Mensality` entities to DTOs.