### PR TITLE
Feat/set up http presenters

### DIFF
--- a/api/src/infra/http/presenters/address-presenter.ts
+++ b/api/src/infra/http/presenters/address-presenter.ts
@@ -1,0 +1,22 @@
+import { Address, AddressProps } from "@core/entities/address";
+
+import { View } from "@infra/types/view";
+
+export class AddressPresenter {
+  static toDTO(address?: Address): View<AddressProps> {
+    if (address)
+      return {
+        id: address.id.value,
+        street: address.street,
+        number: address.number,
+        complement: address.complement,
+        neighborhood: address.neighborhood,
+        city: address.city,
+        state: address.state,
+        country: address.country,
+        zipCode: address.zipCode,
+        createdAt: address.createdAt,
+        updatedAt: address.updatedAt,
+      };
+  }
+}

--- a/api/src/infra/http/presenters/associate-presenter.ts
+++ b/api/src/infra/http/presenters/associate-presenter.ts
@@ -1,15 +1,23 @@
 import { Associate, AssociateProps } from "@core/entities/associate";
 
+import { AddressPresenter } from "@infra/http/presenters/address-presenter";
+import { PaymentPresenter } from "@infra/http/presenters/payment-presenter";
+
 import { View } from "@infra/types/view";
 
 export class AssociatePresenter {
   static toDTO(associate?: Associate): View<AssociateProps> {
     if (associate)
       return {
-        id: associate.id,
+        id: associate.id.value,
         fullName: associate.fullName,
         email: associate.email,
         phone: associate.phone,
+        addressId: associate.addressId,
+        address: AddressPresenter.toDTO(associate.address ?? undefined),
+        payments: Array.from(associate.payments).map(([_, payment]) =>
+          PaymentPresenter.toDTO(payment)
+        ),
         createdAt: associate.createdAt,
         updatedAt: associate.updatedAt,
       };

--- a/api/src/infra/http/presenters/mensality-presenter.ts
+++ b/api/src/infra/http/presenters/mensality-presenter.ts
@@ -1,15 +1,20 @@
 import { Mensality, MensalityProps } from "@core/entities/mensality";
 
+import { PaymentPresenter } from "@infra/http/presenters/payment-presenter";
+
 import { View } from "@infra/types/view";
 
 export class MensalityPresenter {
   static toDTO(mensality?: Mensality): View<MensalityProps> {
     if (mensality)
       return {
-        id: mensality.id,
+        id: mensality.id.value,
         month: mensality.month,
         year: mensality.year,
         priceInCents: mensality.priceInCents,
+        payments: Array.from(mensality.payments).map(([_, payment]) =>
+          PaymentPresenter.toDTO(payment)
+        ),
         createdAt: mensality.createdAt,
         updatedAt: mensality.updatedAt,
       };

--- a/api/src/infra/http/presenters/payment-presenter.ts
+++ b/api/src/infra/http/presenters/payment-presenter.ts
@@ -1,0 +1,23 @@
+import { Payment, PaymentProps } from "@core/entities/payment";
+
+import { AssociatePresenter } from "@infra/http/presenters/associate-presenter";
+import { MensalityPresenter } from "@infra/http/presenters/mensality-presenter";
+
+import { View } from "@infra/types/view";
+
+export class PaymentPresenter {
+  static toDTO(payment?: Payment): View<PaymentProps> {
+    if (payment)
+      return {
+        id: payment.id.value,
+        date: payment.date,
+        associateId: payment.associateId,
+        associate: AssociatePresenter.toDTO(payment.associate ?? undefined),
+        paidMensalities: Array.from(payment.paidMensalities).map(
+          ([_, mensality]) => MensalityPresenter.toDTO(mensality)
+        ),
+        createdAt: payment.createdAt,
+        updatedAt: payment.updatedAt,
+      };
+  }
+}

--- a/api/src/infra/http/presenters/user-presenter.ts
+++ b/api/src/infra/http/presenters/user-presenter.ts
@@ -1,0 +1,20 @@
+import { User, UserProps } from "@core/entities/user";
+
+import { View } from "@infra/types/view";
+
+export class UserPresenter {
+  static toDTO(user?: User): View<UserProps> {
+    if (user)
+      return {
+        id: user.id.value,
+        email: user.email,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        roles: user.roles,
+        active: user.active,
+        verifiedAt: user.verifiedAt,
+        createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+      };
+  }
+}

--- a/api/src/infra/types/view.ts
+++ b/api/src/infra/types/view.ts
@@ -1,3 +1,9 @@
 import { DeepPartial } from "utility-types";
 
-export type View<T extends object> = DeepPartial<T> | void;
+export type View<T extends object> =
+  | ({
+      [K in keyof T]?: DeepPartial<T[K]> | unknown;
+    } & {
+      [key: string]: unknown;
+    })
+  | void;


### PR DESCRIPTION
This pull request introduces several new presenter classes and updates existing ones to improve the conversion of entities to Data Transfer Objects (DTOs). The changes include the addition of new presenters for `Address`, `Payment`, and `User`, as well as modifications to existing presenters for `Associate` and `Mensality`. Additionally, there is an update to the `View` type definition.

### New Presenter Classes:
* [`api/src/infra/http/presenters/address-presenter.ts`](diffhunk://#diff-fbd2caacde31fe1028f51c2c5831c53cc5c728ee9e698c206e6d14e3fa67a46fR1-R22): Added `AddressPresenter` class to convert `Address` entities to DTOs.
* [`api/src/infra/http/presenters/payment-presenter.ts`](diffhunk://#diff-e6bacffd7be623fe73daed8c2cc9b2354a33b6af4a978685b3ab167891ecf515R1-R23): Added `PaymentPresenter` class to convert `Payment` entities to DTOs.
* [`api/src/infra/http/presenters/user-presenter.ts`](diffhunk://#diff-f7e0ce33ae12c3d7df41b04ee69a2e7e588b54926f34911e313a40cf064f7e58R1-R20): Added `UserPresenter` class to convert `User` entities to DTOs.

### Updated Presenter Classes:
* [`api/src/infra/http/presenters/associate-presenter.ts`](diffhunk://#diff-1655c57c0898b04bd91d5f2bd97c0a08c9e3124d4faf229b238e139ebe7d643eR3-R20): Updated `AssociatePresenter` class to include address and payments in the DTO conversion.
* [`api/src/infra/http/presenters/mensality-presenter.ts`](diffhunk://#diff-bced6fe86809a28b01772ff50031ce1bc314b7444a8ce3ca87539c32b0b56a23R3-R17): Updated `MensalityPresenter` class to include payments in the DTO conversion.

### Type Definition Update:
* [`api/src/infra/types/view.ts`](diffhunk://#diff-744b2c4927df547dde7c57d55b976800a63a1e758a0c2ef6750ec32abdfd4fcdL3-R9): Modified the `View` type to allow for more flexible DTO structures.