### PR TITLE
feat(register-payment): implement `register-payment` controller, endpoint, and configure it in swagger docs

### DIFF
--- a/api/src/infra/docs/swagger.ts
+++ b/api/src/infra/docs/swagger.ts
@@ -4,13 +4,14 @@ import { fetchAssociateSchema } from "@infra/http/controllers/fetch-associate";
 import { listAssociatesSchema } from "@infra/http/controllers/list-associates";
 import { registerAssociateSchema } from "@infra/http/controllers/register-associate";
 import { registerMensalitySchema } from "@infra/http/controllers/register-mensality";
+import { registerPaymentSchema } from "@infra/http/controllers/register-payment";
 
 import { SwaggerMapper } from "@infra/docs/swagger-mapper";
 
 const tags = {
   associates: "Associates",
-  payments: "Payments",
   mensalities: "Mensalities",
+  payments: "Payments",
 };
 
 const docs = createDocument({
@@ -110,6 +111,22 @@ const docs = createDocument({
           },
         },
         ...SwaggerMapper.toDocs(registerMensalitySchema),
+      },
+    },
+    "/payments": {
+      post: {
+        tags: [tags.payments],
+        summary: "Register a payment",
+        description: "Register a new payment",
+        responses: {
+          201: {
+            description: "Payment registered successfully",
+          },
+          400: {
+            description: "Bad request",
+          },
+        },
+        ...SwaggerMapper.toDocs(registerPaymentSchema),
       },
     },
   },

--- a/api/src/infra/http/controllers/register-payment.ts
+++ b/api/src/infra/http/controllers/register-payment.ts
@@ -1,0 +1,64 @@
+import container from "@infra/container";
+import { NextFunction, Request, Response } from "express";
+import { z } from "zod";
+import "zod-openapi/extend";
+
+import { RegisterPaymentUseCase } from "@core/use-cases/register-payment";
+
+export const registerPaymentSchema = {
+  body: z.object({
+    associateId: z.string().uuid().openapi({ description: "Associate ID" }),
+    date: z.string().date().optional().openapi({ description: "Payment date" }),
+    mensalities: z.array(
+      z.object({
+        month: z
+          .enum([
+            "JAN",
+            "FEB",
+            "MAR",
+            "APR",
+            "MAY",
+            "JUN",
+            "JUL",
+            "AUG",
+            "SEP",
+            "OCT",
+            "NOV",
+            "DEC",
+          ])
+          .openapi({ description: "Mensality month" }),
+        year: z
+          .number()
+          .int()
+          .positive()
+          .openapi({ description: "Mensality year" }),
+      })
+    ),
+  }),
+};
+
+export async function registerPaymentController(
+  request: Request,
+  response: Response,
+  next: NextFunction
+): Promise<Response | void> {
+  try {
+    const { associateId, date, mensalities } = registerPaymentSchema.body.parse(
+      request.body
+    );
+
+    const registerPaymentUseCase = container.resolve<RegisterPaymentUseCase>(
+      "registerPaymentUseCase"
+    );
+
+    await registerPaymentUseCase.execute({
+      associateId,
+      date: date ? new Date(date) : undefined,
+      mensalities,
+    });
+
+    return response.status(201).send();
+  } catch (error) {
+    next(error);
+  }
+}

--- a/api/src/infra/http/routes/index.ts
+++ b/api/src/infra/http/routes/index.ts
@@ -2,6 +2,7 @@ import { fetchAssociateController } from "@infra/http/controllers/fetch-associat
 import { listAssociatesController } from "@infra/http/controllers/list-associates";
 import { registerAssociateController } from "@infra/http/controllers/register-associate";
 import { registerMensalityController } from "@infra/http/controllers/register-mensality";
+import { registerPaymentController } from "@infra/http/controllers/register-payment";
 import { Router } from "express";
 
 export const router = Router();
@@ -11,3 +12,5 @@ router.post("/associates", registerAssociateController);
 router.get("/associates/:id", fetchAssociateController);
 
 router.post("/mensalities", registerMensalityController);
+
+router.post("/payments", registerPaymentController);


### PR DESCRIPTION
This pull request introduces the functionality to register payments in the API. The changes include adding new schemas, controllers, and routes to handle payment registration.

Key changes:

### Addition of Payment Registration:

* [`api/src/infra/http/controllers/register-payment.ts`](diffhunk://#diff-78a52c7a803ddb788130312ea7a6aa4d90f692864aa64db0adb4037a9455c57bR1-R64): Created a new controller `registerPaymentController` and defined the `registerPaymentSchema` for validating the payment registration requests.
* [`api/src/infra/http/routes/index.ts`](diffhunk://#diff-1344b77389dd0665c1674308dcc816cf70fe40d5bd749ffbcaf874f129bfbdf9R5): Added the `registerPaymentController` to the routes and defined a new POST route for `/payments`. [[1]](diffhunk://#diff-1344b77389dd0665c1674308dcc816cf70fe40d5bd749ffbcaf874f129bfbdf9R5) [[2]](diffhunk://#diff-1344b77389dd0665c1674308dcc816cf70fe40d5bd749ffbcaf874f129bfbdf9R15-R16)
* [`api/src/infra/docs/swagger.ts`](diffhunk://#diff-e9d7fcd9af09946efab15b906fa703aadad4db130f5d8cf88a6cf17210b6a587R7-R14): Added `registerPaymentSchema` import and updated the Swagger documentation to include the new `/payments` endpoint. [[1]](diffhunk://#diff-e9d7fcd9af09946efab15b906fa703aadad4db130f5d8cf88a6cf17210b6a587R7-R14) [[2]](diffhunk://#diff-e9d7fcd9af09946efab15b906fa703aadad4db130f5d8cf88a6cf17210b6a587R116-R131)