### PR TITLE
:recycle: refactor(database): create `PaymentMensality` and `AssociateMensality` join tables

### DIFF
--- a/api/src/infra/database/migrations/20250227153012_add_join_tables_for_associate_mensality_and_payment_mensality/migration.sql
+++ b/api/src/infra/database/migrations/20250227153012_add_join_tables_for_associate_mensality_and_payment_mensality/migration.sql
@@ -1,0 +1,46 @@
+/*
+  Warnings:
+
+  - You are about to drop the `_MensalityToPayment` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "_MensalityToPayment" DROP CONSTRAINT "_MensalityToPayment_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_MensalityToPayment" DROP CONSTRAINT "_MensalityToPayment_B_fkey";
+
+-- DropTable
+DROP TABLE "_MensalityToPayment";
+
+-- CreateTable
+CREATE TABLE "payment_mensalities" (
+    "paymentId" TEXT NOT NULL,
+    "mensalityId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3),
+
+    CONSTRAINT "payment_mensalities_pkey" PRIMARY KEY ("paymentId","mensalityId")
+);
+
+-- CreateTable
+CREATE TABLE "associate_mensalities" (
+    "associateId" TEXT NOT NULL,
+    "mensalityId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3),
+
+    CONSTRAINT "associate_mensalities_pkey" PRIMARY KEY ("associateId","mensalityId")
+);
+
+-- AddForeignKey
+ALTER TABLE "payment_mensalities" ADD CONSTRAINT "payment_mensalities_paymentId_fkey" FOREIGN KEY ("paymentId") REFERENCES "payments"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "payment_mensalities" ADD CONSTRAINT "payment_mensalities_mensalityId_fkey" FOREIGN KEY ("mensalityId") REFERENCES "mensalities"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "associate_mensalities" ADD CONSTRAINT "associate_mensalities_associateId_fkey" FOREIGN KEY ("associateId") REFERENCES "associates"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "associate_mensalities" ADD CONSTRAINT "associate_mensalities_mensalityId_fkey" FOREIGN KEY ("mensalityId") REFERENCES "mensalities"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/src/infra/database/schema.prisma
+++ b/api/src/infra/database/schema.prisma
@@ -79,7 +79,8 @@ model Associate {
   addressId String?
   address   Address? @relation(fields: [addressId], references: [id])
 
-  payments Payment[]
+  payments    Payment[]
+  mensalities AssociateMensality[]
 
   createdAt DateTime  @default(now())
   updatedAt DateTime? @updatedAt
@@ -112,7 +113,7 @@ model Payment {
   associateId String
   associate   Associate @relation(fields: [associateId], references: [id])
 
-  paidMensalities Mensality[]
+  paidMensalities PaymentMensality[]
 
   createdAt DateTime  @default(now())
   updatedAt DateTime? @updatedAt
@@ -126,7 +127,8 @@ model Mensality {
   year         Int
   priceInCents BigInt
 
-  payments Payment[]
+  payments   PaymentMensality[]
+  associates AssociateMensality[]
 
   createdAt DateTime  @default(now())
   updatedAt DateTime? @updatedAt
@@ -134,4 +136,32 @@ model Mensality {
   @@unique([month, year])
   @@index([month, year])
   @@map("mensalities")
+}
+
+model PaymentMensality {
+  paymentId   String
+  mensalityId String
+
+  payment   Payment   @relation(fields: [paymentId], references: [id], onDelete: Cascade)
+  mensality Mensality @relation(fields: [mensalityId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime  @default(now())
+  updatedAt DateTime? @updatedAt
+
+  @@id([paymentId, mensalityId])
+  @@map("payment_mensalities")
+}
+
+model AssociateMensality {
+  associateId String
+  mensalityId String
+
+  associate Associate @relation(fields: [associateId], references: [id], onDelete: Cascade)
+  mensality Mensality @relation(fields: [mensalityId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime  @default(now())
+  updatedAt DateTime? @updatedAt
+
+  @@id([associateId, mensalityId])
+  @@map("associate_mensalities")
 }


### PR DESCRIPTION
This pull request includes significant updates to the database schema and migrations to improve the structure and relationships of the `mensalities` and their associations with `payments` and `associates`. The most important changes include dropping an old join table, creating new join tables, and updating the Prisma schema to reflect these changes.

Database schema and migrations updates:

* [`api/src/infra/database/migrations/20250227153012_add_join_tables_for_associate_mensality_and_payment_mensality/migration.sql`](diffhunk://#diff-2f8912fab0e4741af2ccc756a3cb0d50ed7e80c69e61d56c239dca1bce6d13a9R1-R46): Dropped the `_MensalityToPayment` table and created new tables `payment_mensalities` and `associate_mensalities` with appropriate foreign key constraints.

Prisma schema updates:

* [`api/src/infra/database/schema.prisma`](diffhunk://#diff-2c5ac05a58312360d915c0c7ba3825309afa5ce18be70d0f46fd83fd96fa4ba6R83): Updated the `Associate` model to include a relation to the new `AssociateMensality` model.
* [`api/src/infra/database/schema.prisma`](diffhunk://#diff-2c5ac05a58312360d915c0c7ba3825309afa5ce18be70d0f46fd83fd96fa4ba6L115-R116): Updated the `Payment` model to include a relation to the new `PaymentMensality` model.
* [`api/src/infra/database/schema.prisma`](diffhunk://#diff-2c5ac05a58312360d915c0c7ba3825309afa5ce18be70d0f46fd83fd96fa4ba6L129-R131): Updated the `Mensality` model to include relations to the new `PaymentMensality` and `AssociateMensality` models.
* [`api/src/infra/database/schema.prisma`](diffhunk://#diff-2c5ac05a58312360d915c0c7ba3825309afa5ce18be70d0f46fd83fd96fa4ba6R140-R167): Added new models `PaymentMensality` and `AssociateMensality` to represent the many-to-many relationships between `payments` and `mensalities`, and `associates` and `mensalities`, respectively.