### PR TITLE
:bug: fix(type): use zod number and convert it to `bigint` in `registerMensalitySchema` for `priceInCents` body parameter

### DIFF
--- a/api/src/infra/http/controllers/register-mensality.ts
+++ b/api/src/infra/http/controllers/register-mensality.ts
@@ -28,9 +28,11 @@ export const registerMensalitySchema = {
       .int()
       .positive()
       .openapi({ description: "Mensality year" }),
-    priceInCents: z
-      .bigint()
+    priceInCents: z.coerce
+      .number()
+      .int()
       .positive()
+      .transform((value) => BigInt(value))
       .openapi({ description: "Mensality value in cents" }),
   }),
 };


### PR DESCRIPTION
This pull request includes a change to the `registerMensalitySchema` in the `register-mensality.ts` file to ensure the `priceInCents` field is correctly handled as a number and then transformed to a BigInt. This change improves the schema validation and data transformation process.

Key change:

* [`api/src/infra/http/controllers/register-mensality.ts`](diffhunk://#diff-7fdf8caf890b28c7db400b760856b5ff331de8101ef323a7323240b6ca859809L31-R35): Updated `priceInCents` to use `z.coerce.number().int().positive().transform((value) => BigInt(value))` for proper type handling and transformation.