### PR TITLE
Refactor/register payment

### DIFF
--- a/api/src/infra/http/controllers/register-payment.ts
+++ b/api/src/infra/http/controllers/register-payment.ts
@@ -7,7 +7,7 @@ import { RegisterPaymentUseCase } from "@core/use-cases/register-payment";
 
 export const registerPaymentSchema = {
   body: z.object({
-    associateId: z.string().uuid().openapi({ description: "Associate ID" }),
+    associateId: z.string().cuid2().openapi({ description: "Associate ID" }),
     date: z.string().date().optional().openapi({ description: "Payment date" }),
     mensalities: z.array(
       z.object({

--- a/api/src/infra/http/presenters/mensality-presenter.ts
+++ b/api/src/infra/http/presenters/mensality-presenter.ts
@@ -1,7 +1,5 @@
 import { Mensality, MensalityProps } from "@core/entities/mensality";
 
-import { PaymentPresenter } from "@infra/http/presenters/payment-presenter";
-
 import { View } from "@infra/types/view";
 
 export class MensalityPresenter {
@@ -12,9 +10,6 @@ export class MensalityPresenter {
         month: mensality.month,
         year: mensality.year,
         priceInCents: mensality.priceInCents.toString().normalize(),
-        payments: Array.from(mensality.payments).map(([_, payment]) =>
-          PaymentPresenter.toDTO(payment)
-        ),
         createdAt: mensality.createdAt,
         updatedAt: mensality.updatedAt,
       };

--- a/api/src/infra/http/presenters/payment-presenter.ts
+++ b/api/src/infra/http/presenters/payment-presenter.ts
@@ -1,9 +1,9 @@
 import { Payment, PaymentProps } from "@core/entities/payment";
 
 import { AssociatePresenter } from "@infra/http/presenters/associate-presenter";
-import { MensalityPresenter } from "@infra/http/presenters/mensality-presenter";
 
 import { View } from "@infra/types/view";
+import { MensalityPresenter } from "./mensality-presenter";
 
 export class PaymentPresenter {
   static toDTO(payment?: Payment): View<PaymentProps> {
@@ -13,8 +13,8 @@ export class PaymentPresenter {
         date: payment.date,
         associateId: payment.associateId,
         associate: AssociatePresenter.toDTO(payment.associate ?? undefined),
-        paidMensalities: Array.from(payment.paidMensalities).map(
-          ([_, mensality]) => MensalityPresenter.toDTO(mensality)
+        mensalities: payment.mensalities.flatMap((mensality) =>
+          MensalityPresenter.toDTO(mensality.mensality ?? undefined)
         ),
         createdAt: payment.createdAt,
         updatedAt: payment.updatedAt,


### PR DESCRIPTION
This pull request includes several changes to the payment registration use case and related presenters. The most important changes are focused on updating the `RegisterPaymentUseCase` class to include the `AssociatesRepository`, modifying the structure of mensalities, and updating the schema and presenters accordingly.

### Use Case Updates:
* [`api/src/core/use-cases/register-payment.ts`](diffhunk://#diff-98dc017a660acc8786b874314c21036f281bf6bbc3757086e972b512a7150b81L3-R4): Added `AssociatesRepository` to the `RegisterPaymentUseCase` constructor and updated the logic to handle associates and mensalities more robustly. [[1]](diffhunk://#diff-98dc017a660acc8786b874314c21036f281bf6bbc3757086e972b512a7150b81L3-R4) [[2]](diffhunk://#diff-98dc017a660acc8786b874314c21036f281bf6bbc3757086e972b512a7150b81L16-R18) [[3]](diffhunk://#diff-98dc017a660acc8786b874314c21036f281bf6bbc3757086e972b512a7150b81L28-R64)

### Schema Changes:
* [`api/src/infra/http/controllers/register-payment.ts`](diffhunk://#diff-78a52c7a803ddb788130312ea7a6aa4d90f692864aa64db0adb4037a9455c57bL10-R10): Changed the validation schema for `associateId` to use `cuid2` instead of `uuid`.

### Presenter Updates:
* [`api/src/infra/http/presenters/mensality-presenter.ts`](diffhunk://#diff-bced6fe86809a28b01772ff50031ce1bc314b7444a8ce3ca87539c32b0b56a23L3-L4): Removed the inclusion of payments from the mensality DTO. [[1]](diffhunk://#diff-bced6fe86809a28b01772ff50031ce1bc314b7444a8ce3ca87539c32b0b56a23L3-L4) [[2]](diffhunk://#diff-bced6fe86809a28b01772ff50031ce1bc314b7444a8ce3ca87539c32b0b56a23L15-L17)
* [`api/src/infra/http/presenters/payment-presenter.ts`](diffhunk://#diff-e6bacffd7be623fe73daed8c2cc9b2354a33b6af4a978685b3ab167891ecf515L4-R6): Updated the `PaymentPresenter` to use the new structure of mensalities. [[1]](diffhunk://#diff-e6bacffd7be623fe73daed8c2cc9b2354a33b6af4a978685b3ab167891ecf515L4-R6) [[2]](diffhunk://#diff-e6bacffd7be623fe73daed8c2cc9b2354a33b6af4a978685b3ab167891ecf515L16-R17)