### PR TITLE
feat(register-associate): create the register associate component and add it to the `/associates` page

### DIFF
--- a/front/src/app/associates/components/RegisterAssociate/RegisterAssociateForm.tsx
+++ b/front/src/app/associates/components/RegisterAssociate/RegisterAssociateForm.tsx
@@ -1,0 +1,102 @@
+import { registerAssociate } from "@/_actions/associates/POST/register-associate";
+import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+const registerAssociateFormSchema = z.object({
+  fullName: z.string().nonempty("Full name is required"),
+  email: z.string().email("Invalid email address"),
+  phone: z.string().nonempty("Phone is required"),
+});
+
+type RegisterAssociateFormSchema = z.infer<typeof registerAssociateFormSchema>;
+
+export default function RegisterAssociateForm() {
+  const form = useForm<RegisterAssociateFormSchema>({
+    resolver: zodResolver(registerAssociateFormSchema),
+    defaultValues: {
+      fullName: "",
+      email: "",
+      phone: "",
+    },
+  });
+
+  const onSubmit = async (data: RegisterAssociateFormSchema) => {
+    try {
+      const response = await registerAssociate(data);
+
+      if (response.message) {
+        throw new Error(response.message);
+      }
+
+      form.reset();
+      toast.success("Associate registered successfully");
+    } catch {
+      toast.error("Failed to register associate");
+    } finally {
+      return;
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="fullName"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Full name</FormLabel>
+              <FormControl>
+                <Input placeholder="Enter full name..." {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>E-mail</FormLabel>
+              <FormControl>
+                <Input placeholder="Enter e-mail..." {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="phone"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Phone</FormLabel>
+              <FormControl>
+                <Input placeholder="Enter phone..." {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" disabled={form.formState.isSubmitting}>
+          {form.formState.isSubmitting && <LoadingSpinner />}
+          Register
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/front/src/app/associates/components/RegisterAssociate/index.tsx
+++ b/front/src/app/associates/components/RegisterAssociate/index.tsx
@@ -1,0 +1,25 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import RegisterAssociateForm from "./RegisterAssociateForm";
+
+export function RegisterAssociate() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-2xl font-bold">Register Associate</CardTitle>
+        <CardDescription>
+          Enter the associate information to register. The ID will be generated
+          automatically.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <RegisterAssociateForm />
+      </CardContent>
+    </Card>
+  );
+}

--- a/front/src/app/associates/page.tsx
+++ b/front/src/app/associates/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { motion } from "motion/react";
+import { RegisterAssociate } from "./components/RegisterAssociate";
+
+export default function AssociatesPage() {
+  return (
+    <div className="grid gap-6">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        exit={{ opacity: 0, y: 20 }}
+      >
+        <h1 className="text-3xl font-bold">Associates Management</h1>
+        <p className="text-muted-foreground mt-2">
+          Register and manage your associates
+        </p>
+      </motion.div>
+      <div className="grid gap-6 md:grid-cols-2">
+        <RegisterAssociate />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces a new feature for registering associates on the associates management page. The changes include creating a form component, a card component to wrap the form, and integrating these components into the main associates page with animations.

New components and integration:

* [`front/src/app/associates/components/RegisterAssociate/RegisterAssociateForm.tsx`](diffhunk://#diff-2909e3435bbd46b3e3f30021dbe31eedbc5468d1322a0fe843a546d7d059f075R1-R102): Added a form for registering associates, including validation and form submission logic.
* [`front/src/app/associates/components/RegisterAssociate/index.tsx`](diffhunk://#diff-cefedc80521370563f7301d37119a8dc23b83fc69cddc44404661d4e87dd86f0R1-R25): Created a card component to wrap the registration form, providing a title and description.
* [`front/src/app/associates/page.tsx`](diffhunk://#diff-7008c609d06d5a66af05eb39214695a3bf4a648eb8360a3bc61cada2b29457ddR1-R24): Integrated the new registration card into the associates management page with animations for a smoother user experience.