### PR TITLE
Fix/list associates pagination

### DIFF
--- a/api/src/core/repositories/associates-repository.ts
+++ b/api/src/core/repositories/associates-repository.ts
@@ -22,7 +22,7 @@ export interface AssociatesRepository {
   list(
     mode: RepositoryQueryMode,
     filters: AssociatesRepositoryFilterOptions,
-    page?: number,
+    page: number,
     take?: number
   ): Promise<Associate[] & { next?: number | null; prev?: number | null }>;
 }

--- a/api/src/core/use-cases/associates/list-associates.ts
+++ b/api/src/core/use-cases/associates/list-associates.ts
@@ -1,18 +1,20 @@
 import { AssociatesRepository } from "@core/repositories/associates-repository";
 
 interface ListAssociatesUseCaseRequest {
+  page: number;
   name?: string;
-  page?: number;
   take?: number;
 }
 
 export class ListAssociatesUseCase {
   constructor(private associatesRepository: AssociatesRepository) {}
 
-  async execute({ name, page, take }: ListAssociatesUseCaseRequest) {
+  async execute({ name, page, take = 10 }: ListAssociatesUseCaseRequest) {
     const associates = await this.associatesRepository.list(
       "minimal",
-      { fullName: name },
+      {
+        fullName: name,
+      },
       page,
       take
     );

--- a/api/src/infra/database/repositories/prisma-associates-repository.ts
+++ b/api/src/infra/database/repositories/prisma-associates-repository.ts
@@ -52,8 +52,6 @@ export class PrismaAssociatesRepository implements AssociatesRepository {
     page: number,
     take: number = 10
   ): Promise<Associate[] & { next?: number | null; prev?: number | null }> {
-    console.log({ page, take, fullName, year });
-
     const [associates, count] = await Promise.all([
       prisma.associate.findMany({
         where: {
@@ -101,10 +99,6 @@ export class PrismaAssociatesRepository implements AssociatesRepository {
         },
       }),
     ]);
-
-    // console.log({ associates });
-    console.log({ count });
-    console.log({ page, take });
 
     return Object.assign(
       associates.map(PrismaAssociateMapper.toEntity),

--- a/api/src/infra/http/controllers/associates/list-associates.ts
+++ b/api/src/infra/http/controllers/associates/list-associates.ts
@@ -10,7 +10,7 @@ import { AssociatePresenter } from "@infra/http/presenters/associate-presenter";
 export const listAssociatesSchema = {
   query: z.object({
     name: z.string().optional().openapi({ description: "Associate name" }),
-    page: z.coerce.number().int().positive().default(1).optional().openapi({
+    page: z.coerce.number().int().positive().default(1).openapi({
       description: "Page number",
     }),
     perPage: z.coerce.number().int().positive().default(10).optional().openapi({
@@ -29,6 +29,8 @@ export async function listAssociatesController(
       request.query
     );
 
+    console.log({ name, page, perPage });
+
     const listAssociatesUseCase = container.resolve<ListAssociatesUseCase>(
       "listAssociatesUseCase"
     );
@@ -38,6 +40,8 @@ export async function listAssociatesController(
       page: page,
       take: perPage,
     });
+
+    console.log(associates);
 
     return response
       .status(200)

--- a/api/src/infra/http/controllers/associates/list-associates.ts
+++ b/api/src/infra/http/controllers/associates/list-associates.ts
@@ -29,8 +29,6 @@ export async function listAssociatesController(
       request.query
     );
 
-    console.log({ name, page, perPage });
-
     const listAssociatesUseCase = container.resolve<ListAssociatesUseCase>(
       "listAssociatesUseCase"
     );
@@ -40,8 +38,6 @@ export async function listAssociatesController(
       page: page,
       take: perPage,
     });
-
-    console.log(associates);
 
     return response
       .status(200)


### PR DESCRIPTION
This pull request includes several important changes to the `associates` feature in the API. The primary focus is on making the `page` parameter required across various parts of the codebase, ensuring consistency and improving the handling of pagination.

### Pagination Parameter Changes:

* [`api/src/core/repositories/associates-repository.ts`](diffhunk://#diff-e7dca72475e91336e91094600e2715e183f0c0f3a11ae21a28b98df21fcc0afbL25-R25): Made the `page` parameter mandatory in the `list` method of the `AssociatesRepository` interface.
* [`api/src/core/use-cases/associates/list-associates.ts`](diffhunk://#diff-1799c847491e21154360237096f10ae2d3166bff00763bf121df83c0f9a73554R4-R17): Updated the `ListAssociatesUseCaseRequest` interface to make `page` a required parameter and set a default value for `take` in the `execute` method.

### Repository Implementation Adjustments:

* [`api/src/infra/database/repositories/prisma-associates-repository.ts`](diffhunk://#diff-7b1c6a1231e5a5b73ce424937037688e9378aeeb36f89b4a00b08eb35f3d9c13L51-R58): Adjusted the `list` method in `PrismaAssociatesRepository` to require the `page` parameter and handle pagination logic more explicitly. [[1]](diffhunk://#diff-7b1c6a1231e5a5b73ce424937037688e9378aeeb36f89b4a00b08eb35f3d9c13L51-R58) [[2]](diffhunk://#diff-7b1c6a1231e5a5b73ce424937037688e9378aeeb36f89b4a00b08eb35f3d9c13R72-R111)

### API Schema Updates:

* [`api/src/infra/http/controllers/associates/list-associates.ts`](diffhunk://#diff-23fd4daf1633bbc7c34271d500fc67515ad9e7dcc9381ff277f2749d74ab07aaL13-R13): Removed the optional flag from the `page` parameter in the `listAssociatesSchema` to reflect the new requirement.