### PR TITLE
Feat/theme switcher component

### DIFF
--- a/front/src/app/settings/components/ThemeCard.tsx
+++ b/front/src/app/settings/components/ThemeCard.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import ThemeSwitch from "@/components/ThemeSwitcher";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { motion } from "motion/react";
+
+export default function ThemeCard() {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: 0.2 }}
+    >
+      <Card>
+        <CardHeader>
+          <CardTitle>Theme</CardTitle>
+          <CardDescription>Choose between light and dark mode</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center space-x-2">
+            <ThemeSwitch />
+            <span className="text-sm text-muted-foreground">
+              Toggle between light and dark mode
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+}

--- a/front/src/app/settings/page.tsx
+++ b/front/src/app/settings/page.tsx
@@ -1,0 +1,16 @@
+import PageHeaderInfo from "@/components/PageHeaderInfo";
+import ThemeCard from "./components/ThemeCard";
+
+export default function SettingsPage() {
+  return (
+    <>
+      <PageHeaderInfo
+        title="Settings"
+        description="Manage your application settings and database"
+      />
+      <div className="gap-6 flex flex-col">
+        <ThemeCard />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
This pull request introduces a new `ThemeCard` component and updates the `SettingsPage` to include it. The `ThemeCard` component allows users to toggle between light and dark modes.

New component addition:

* [`front/src/app/settings/components/ThemeCard.tsx`](diffhunk://#diff-b9158dd6e9e75f39f21f07769c8262e3f3af57dd5fcf01ec368443d5892c51acR1-R36): Added a new `ThemeCard` component that includes a `ThemeSwitch` and uses the `motion` library for animation. The card provides an interface for users to switch between light and dark themes.

Page update:

* [`front/src/app/settings/page.tsx`](diffhunk://#diff-10b00530258e8ae54f934d8ae8fd16d80566a8bcfeb3befafc6086d0f6b22a1bR1-R16): Updated the `SettingsPage` to include the new `ThemeCard` component and a `PageHeaderInfo` component to provide a header with a title and description.